### PR TITLE
Proof of concept: add browser/Cloudflare support with webcrypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "version": "0.3.0",
   "license": "MIT",
   "main": "dist/index.js",
+  "browser": "dist/browser.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
@@ -28,6 +29,7 @@
   "author": "Simon Knott",
   "module": "dist/secure-webhooks.esm.js",
   "devDependencies": {
+    "@peculiar/webcrypto": "^1.1.7",
     "@types/node": "16.7.12",
     "husky": "7.0.2",
     "tsdx": "0.14.1",

--- a/src/browser.spec.ts
+++ b/src/browser.spec.ts
@@ -1,0 +1,124 @@
+import { Crypto } from '@peculiar/webcrypto';
+
+// Emulate a browser environment and polyfill WebCrypto, TextEncoder
+// @ts-ignore
+window.crypto = new Crypto();
+
+import { SecureWebhooks, symmetric, asymmetric } from './browser';
+
+async function testWithKeyPair(
+  swh: SecureWebhooks,
+  pub: string,
+  priv: string,
+  expectedResult: string
+) {
+  const input = 'hello world';
+  const timestamp = 1600000000000;
+  const signature = await swh.sign(input, priv, timestamp);
+  expect(signature).toEqual(expectedResult);
+
+  // transmit input + signature over the wire
+
+  const receivingTimestamp = timestamp + 60 * 1000;
+
+  const isValidIfWithinTimeout = await swh.verify(input, pub, signature, {
+    timestamp: receivingTimestamp,
+  });
+  expect(isValidIfWithinTimeout).toBe(true);
+
+  const isValidIfOverTimeout = await swh.verify(input, pub, signature, {
+    timestamp: receivingTimestamp,
+    timeout: 0.5 * 60 * 1000,
+  });
+  expect(isValidIfOverTimeout).toBe(false);
+}
+
+test('symmetric', async () => {
+  const secret = 'iamverysecret';
+  await testWithKeyPair(
+    symmetric,
+    secret,
+    secret,
+    `v=1600000000000,d=3bd0b48300a7a7afc491e90ecef6805cb46813ea047434eed9cccc567f7aeecb`
+  );
+});
+
+test('asymmetric', async () => {
+  const publicKey = `
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqmeVACnRiy7Em4TJ2hev
+BQJek3ryctBaMQZKULAUg/+3Gk3CNgY/ZoWpFFlwnlIb60KuNAIIev8PEd63F3Ut
+98UaiTiZnsqMN6j7SyPoSDMP5viFZN8pu+xwn6VoGS0y/7fGs8kV+4i96dh2ev0t
+704E8l8CApVi607IN9NhaAgZrYHW4kTZb1UNcVSKYiG3U4J2e6HNeSIon4Ww7tdM
+/6JEJWmKYybRzlGVDjZ5NYqRE+kTK1Dvlj525aJEVPy8AZzH53AwfIpukoz571vo
+MKWgSypiyKPsXxs6AtaZfpWxLfz4VF0UlPr3Shf1CUls4llr6bFBRWub7YhQgiwF
+14KkdmU/g5DnqiW8jG5P+D5suV8kLUaqtm47IfrGhb548/lrh6f9/fFgx+YXjweM
+damh5jggjFPUGM3X7glIhl29v/js8HXyrFyuj97rS2G3ni36CAvTmZs4FCepmJAF
+8EWFSUo4193mrFjuOeaWfGxqwUQ14W1TsHVEDWgptpO8RU3BNtP3dItY1iTbmIFG
+2lisGb7ynitJ1vItme0Yd6MeelQjVRTi9vfHQawfm5D8kW6dT/ozKFMmffIphQkg
+wa4xcerb9UQRMMMzgOy3HvQO2b7u0Wt/sm4IJlmI1/lBDYlcm4jt/69CvFw1C+3Z
+2ud5X92lVG0AqFzycFCMyzUCAwEAAQ==
+-----END PUBLIC KEY-----
+`.trim();
+  const privateKey = `
+-----BEGIN PRIVATE KEY-----
+MIIJQwIBADANBgkqhkiG9w0BAQEFAASCCS0wggkpAgEAAoICAQCqZ5UAKdGLLsSb
+hMnaF68FAl6TevJy0FoxBkpQsBSD/7caTcI2Bj9mhakUWXCeUhvrQq40Agh6/w8R
+3rcXdS33xRqJOJmeyow3qPtLI+hIMw/m+IVk3ym77HCfpWgZLTL/t8azyRX7iL3p
+2HZ6/S3vTgTyXwIClWLrTsg302FoCBmtgdbiRNlvVQ1xVIpiIbdTgnZ7oc15Iiif
+hbDu10z/okQlaYpjJtHOUZUONnk1ipET6RMrUO+WPnblokRU/LwBnMfncDB8im6S
+jPnvW+gwpaBLKmLIo+xfGzoC1pl+lbEt/PhUXRSU+vdKF/UJSWziWWvpsUFFa5vt
+iFCCLAXXgqR2ZT+DkOeqJbyMbk/4Pmy5XyQtRqq2bjsh+saFvnjz+WuHp/398WDH
+5hePB4x1qaHmOCCMU9QYzdfuCUiGXb2/+OzwdfKsXK6P3utLYbeeLfoIC9OZmzgU
+J6mYkAXwRYVJSjjX3easWO455pZ8bGrBRDXhbVOwdUQNaCm2k7xFTcE20/d0i1jW
+JNuYgUbaWKwZvvKeK0nW8i2Z7Rh3ox56VCNVFOL298dBrB+bkPyRbp1P+jMoUyZ9
+8imFCSDBrjFx6tv1RBEwwzOA7Lce9A7Zvu7Ra3+ybggmWYjX+UENiVybiO3/r0K8
+XDUL7dna53lf3aVUbQCoXPJwUIzLNQIDAQABAoICAGmJX3nLbJDj9TZQZmdhVa8n
+iYWTlsbPDZzhRXN1qi8aV7+9uvOUqP2I+G+2+Q3E0q/BC30AaVorz5yEsCaiF0cl
+1sp3uITk8zShvokKAxl8LnQhJRSVNhbCV/o4CiHVoYlIu5KrjqbLSLukqbSAS0uz
+qVKmzurktHAByfTxQJmasrSH/psCgxv1tC6lalNeiFj7KwBk9In6QuiRd0RlKbYF
+PGljVScVasl6M3Oq/yTO3g1Tw+CG7uvBYgfUmLd+E7536EMJc64eWl7/WugIpuRC
+H+WNqcKT65f3l9UcLdJ9SU+vJemyAEZIrJFCByuqQvpo4XHJqyAghmD1lM8aDr8o
+shZVoutELjzK8hVdi6Hw9gJMchrKMi7kcp8ctrRC5dBNHi2JdTadzEUvw+gXOWrk
+cFygn3KVbn4oBD2FpokMwgBxOd6M8mZpycX9/V65IsbcjPJtenx8YUOdcW40RPNb
+uGHFo5GMOVZVt5my9oHc8oQuuY33mwKsohtesaiDK34doeRRiH6D+TUT/W8O2hnv
++hkatTlBTQjG/7gapSh2uF510vYIiIeRLkb8sGIaLhhd3VQmxhoL2lI9ixqNZD/l
+U1qlZjWOFXEo1JPjCLvEEt5p+4aVp/8h7gfWoKY4296FmYD7OpJ2Qtxk3XeXDaWH
+8DXrkVSszu6d/v4YsL19AoIBAQDYqnpq0h+O/cYd6TydfAXFmLlMBBNqZWnrSonu
+WptaFSzjt3roD9iE55dMUwGRS4ipos6TVynY82bJK0MpdBnFwoDOzcRhTaw5CVnx
+zHXdDYtSPRHE5uzNK4Ug8HQB1JXwx4yA1ikfcZlBpVrUKPzx1z5ZT1SdyV8sHp6o
+6cepJPS8te3JJKBIAW3tE10mVqRLF6V+vfuemWtab1nBIge78XdHNhyO7tecLrvv
+VjKjJrHVa6CJDkqWKnminsDJK2Q4ahyjzD5NvNb0r57M1+aUKpOpvvhZ4tWyNsXl
+kgSOUTYozuNi8W3VoDDM2etdZH7ybsux30PpG28YhKEY9lHLAoIBAQDJVx16JSFo
+7ls6UjJVDo5kntLBUCdOKjwDrXuJxuCMmoDclTxAQbPZ6Lml47XwtArw2ffbGmk6
+uJwhGsFHJxzOgZf2DfFJaQe05Bm0Dr11q0224wT1FXHL1jqoXKt/kmcpa0zY/lQm
+UuYm/wGH08m+DCc/jnd1xwP7RGaMjyZE0IMi5xUtFCh3cKd6Jhm8hwqG7cZvE/7t
+P9tCnnmGxWEtOU2pn+PXNGxLQUf6b8SbHCM/uRyi+ZtRchK0VYcMdKj3IuGZoP/q
+OEa4OJwJLMyUpzLigm+ptjZATes0pNJPjpu1coaQPUHwnBn4aIoi0fTu0VyGTF3w
+zZT3kp+hwbb/AoIBAQCJJzGjGSxdCgw1twVl87J7qPfzRMk9msD37xFtTvH0jl8C
+L42gBRfc2fWOnSTq4tO5/pOh9ZVJ/ppcUgSL4zDFXSDIyLy9k7unx2GmjPU3X3GI
+N5xd9oiEQD5f4Zat6fKYntk0XV1eyDxpr9DVaLTmKokPZAZ+c5DJjwCEkKiRTBGY
+u9mwcHz919nML2vR7xrFZkye9Iiplxi8AKziczZOJMaKz5g4ar0V4weYtAoN+Vqt
+bRoMaH2SnYSuCqyjK9KfW5yRm6L89sNj1SBDL5CIzoL2+yqfS9ZWoBGaB1rW9FXC
+c2TBp28Nwf/iTTiOwCUUNkq/aEPG9lTXQm3wLU0NAoIBAE3AEmYEyK4Yvan76+vk
+vyAkJQb5yPPqY1qYN8iwwC4LzA9ioe2+cZGIyYhCMxRMspznz0sRG+nNOJ2gE1tC
+w2ELsn8WS0MqCAvWugZKWueBy3UAnf121ob8p5I0lxWgl63q/bYeIKjcAny0pQaq
+xpFZaB6nCYK149e4RlGpRgH0828bBZZu3mGhY0tMQ0wGag5I7AQhGKTNsAI96Hge
+6LPqGQ+T6wxD9j3pa75OQwITD5mgBmr5MP12q7pv/MLWmhk1oyEMh0cPjF+/nKH+
+ZtJQ7tmBvVUwRCr47AdcTsriK0caftRck4YzAeRnmlBv+8Htn2lNPEmtWgVw3aw9
+fkkCggEBAJACyRu6wD7ykK/KAEERBG98948g4L3+6eQn/n6eUR7QjgUe3y78/3Pm
+T0OaShIHZWzbH/VdHGMls7SXBCCmG1Xrhb5Dz8osRjNnIWBpWNKZUrbIAqmJVUcD
+okqPNpRDPMJTizU2fPKDTM+vkJuplyFtRqLVDU9614hFoIz/d5vd4h5HzEs8sEXe
+RczWgAwBY9+pWdAD1Wfr4FZRLUyrMijMQsPJLoIK9rg7VtBqKWE5YcwJe6wQy+hI
+wKDtd+zxvDXMSqQQZjrK8PfIOgcA6uR8m6fc155bzz0/HEEpeW1qfPaPy87zponu
+diGo3c5lzEb/84JXcGhvK9Uy4ck2F/M=
+-----END PRIVATE KEY-----
+`.trim();
+
+  await testWithKeyPair(
+    asymmetric,
+    publicKey,
+    privateKey,
+    `v=1600000000000,d=OwH2f2zKu8DHzCrlFKW36VzOZG6hmhtMCN5kVqX3BQTFkjPl7cri4Ar+yky0nyPNYfZG+Q1Kf3fithV8ufy+q25TZC2IXyhPpnytZTfKptlpLT3BGJ0Q1TMx1gQXrEFN2kzl1pH5ertxN1MwYuUnQCwfwigALKeaStADSZAJVVS25Tp+6DB8OrNpywjeruQZ6fUIWtWcF9q2O987zj+uUqya4GvUsa1NI9PFIXUb82e6ZXpw+0fqLNsHLYj60YqdCfeivxs3O+HGJekvqwJuj/bPCftbDBT4Cj4s5sjFYHtV3Rf2ERzu0ycIJD4BXC3oOyek1PX5lbaIRL7JwMpTWir98FjWEbSSlNbNeR/EEzVtKGwgWcEAlO33H4sBKhc1/OPKcAyMU8NFuudeUSrGSNzl9+qLIJkX+oFyct5iksZPbiyypI2NsrTZcY4W6yOpb5lq8gmNu+N2GfwkK57oL0Kj4q+zZuVrGFRQYTrgWVHbJhMhFpnIKGnFg71oIkfqxjn6dWesADVVgKyLoQ0ZE8E/2kc8Kt+pgPkun/ywMfyItOf9AyIgultGsKyQgPpS3aIioJLExuicNsci7brbXJXMo+grccV7GhgDnbGLn1uLrtE0zCh9d/Op0czWKRbLVzCPNAKIYW1+hkaTNROGs/Cu7vhOy7g766YtEX6EWpo=`
+  );
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -16,9 +16,17 @@ function timingSafeEqual(one: string, two: string): boolean {
   return !different;
 }
 
-// Borrowed from https://stackoverflow.com/a/40031979
+// Borrowed from https://github.com/LinusU/array-buffer-to-hex/blob/master/index.js
 function arrayBufferToHex(buffer: ArrayBuffer): string {
-  return [...new Uint8Array(buffer)].map(x => x.toString(16).padStart(2, '0')).join('');
+  const view = new Uint8Array(buffer);
+  let result = '';
+
+  for (let i = 0; i < view.length; i++) {
+    let value = view[i].toString(16)
+    result += (value.length === 1 ? '0' + value : value)
+  }
+
+  return result;
 }
 
 // Borrowed from https://stackoverflow.com/a/67082926

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,171 @@
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+// Borrowed and modified from https://github.com/lukeed/worktop/commit/200999a5fccea4cfd559a14d1aff6e191715f354
+function timingSafeEqual(one: string, two: string): boolean {
+  let different = false;
+
+  const a = stringToUint8Array(one);
+  const b = stringToUint8Array(two);
+
+  if (a.byteLength !== b.byteLength) different = true;
+  let len = a.length;
+  while (len-- > 0) {
+    // must check all items until complete
+    if (a[len] !== b[len]) different = true;
+  }
+  return !different;
+}
+
+// Borrowed from https://stackoverflow.com/a/40031979
+function arrayBufferToHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map(x => x.toString(16).padStart(2, '0')).join('');
+}
+
+// Borrowed from https://stackoverflow.com/a/67082926
+function arrayBufferToString(buffer: ArrayBuffer) {
+  return String.fromCharCode.apply(null, Array.from(new Uint8Array(buffer)));
+}
+
+// Borrowed and modified from https://stackoverflow.com/a/67082926
+function stringToArrayBuffer(str: string): ArrayBuffer {
+  const buffer = new ArrayBuffer(str.length);
+  stringToUint8Array(str, buffer);
+  return buffer;
+}
+
+function stringToUint8Array(str: string, buffer = new ArrayBuffer(str.length)): Uint8Array {
+  const bufferInterface = new Uint8Array(buffer);
+  Array.from(str).forEach((char, index: number) => bufferInterface[index] = char.charCodeAt(0));
+  return bufferInterface;
+}
+
+function makeSecureWebhooks(
+  getSigner: (secretOrPrivateKey: string) => (input: string) => Promise<string>,
+  getVerifier: (
+    secretOrPublicKey: string
+  ) => (input: string, digest: string) => Promise<boolean>
+) {
+  return {
+    async sign(
+      input: string,
+      secretOrPrivateKey: string,
+      timestamp: number = Date.now()
+    ): Promise<string> {
+      const signer = getSigner(secretOrPrivateKey);
+
+      return `v=${timestamp},d=${await signer(input + timestamp)}`;
+    },
+    async verify(
+      input: string,
+      secret: string,
+      signature: string,
+      opts: { timeout?: number; timestamp?: number } = {}
+    ): Promise<boolean> {
+      const match = /v=(\d+),d=(.*)/.exec(signature);
+      if (!match) {
+        return false;
+      }
+
+      const poststamp = Number(match[1]);
+      const postDigest = match[2];
+
+      const timestamp = opts?.timestamp ?? Date.now();
+      const timeout = opts?.timeout ?? FIVE_MINUTES;
+
+      const difference = Math.abs(timestamp - poststamp);
+      if (difference > timeout) {
+        return false;
+      }
+
+      const verifier = getVerifier(secret);
+
+      return verifier(input + poststamp, postDigest);
+    },
+  };
+}
+
+export type SecureWebhooks = ReturnType<typeof makeSecureWebhooks>;
+
+export const symmetric = makeSecureWebhooks(
+  secret => async input => {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      stringToArrayBuffer(secret),
+      {name: 'HMAC', hash: 'SHA-256'},
+      false,
+      ['sign']
+    );
+    const computedSignature = await crypto.subtle.sign('HMAC', key, stringToArrayBuffer(input));
+
+    return arrayBufferToHex(computedSignature);
+  },
+  secret => async (input, digest) => {
+    const key = await crypto.subtle.importKey(
+      'raw',
+      stringToArrayBuffer(secret),
+      {name: 'HMAC', hash: 'SHA-256'},
+      false,
+      ['sign']
+    );
+    const computedSignature = await crypto.subtle.sign('HMAC', key, stringToArrayBuffer(input));
+    const signature = arrayBufferToHex(computedSignature);
+
+    return timingSafeEqual(signature, digest);
+  }
+);
+
+export const asymmetric = makeSecureWebhooks(
+  priv => async input => {
+    const decodedKey = atob(priv
+      .replace("-----BEGIN PRIVATE KEY-----", '')
+      .replace("-----END PRIVATE KEY-----", '')
+      .replace(/\n/g, ''));
+
+    // IMPORTANT: Test keys had to be converted to PKCS#8 because subtle crypto does not support PKCS#1
+    const key = await crypto.subtle.importKey(
+      'pkcs8',
+      stringToUint8Array(decodedKey),
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      false,
+      ['sign']
+    );
+
+    const computedSignature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key, stringToArrayBuffer(input));
+    return btoa(arrayBufferToString(computedSignature));
+  },
+  pub => async (input, digest) => {
+    const decodedKey = atob(pub
+      .replace("-----BEGIN PUBLIC KEY-----", '')
+      .replace("-----END PUBLIC KEY-----", '')
+      .replace(/\n/g, ''));
+
+    const key = await crypto.subtle.importKey(
+      'spki',
+      stringToUint8Array(decodedKey),
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      false,
+      ['verify']
+    );
+
+    return await crypto.subtle.verify(
+      'RSASSA-PKCS1-v1_5',
+      key,
+      stringToArrayBuffer(atob(digest)),
+      stringToArrayBuffer(input)
+    );
+  }
+);
+
+export const combined: SecureWebhooks = {
+  sign: (input, secretOrPrivateKey, timestamp) =>
+    secretOrPrivateKey.includes('PRIVATE KEY')
+      ? asymmetric.sign(input, secretOrPrivateKey, timestamp)
+      : symmetric.sign(input, secretOrPrivateKey, timestamp),
+  verify: (input, secretOrPublicKey, signature, opts) =>
+    secretOrPublicKey.includes('PUBLIC KEY')
+      ? asymmetric.verify(input, secretOrPublicKey, signature, opts)
+      : symmetric.verify(input, secretOrPublicKey, signature, opts),
+};
+
+export const sign = symmetric.sign;
+export const verify = symmetric.verify;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    "downlevelIteration": true,
     "moduleResolution": "node",
     "jsx": "react",
     "esModuleInterop": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,6 +1158,34 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@peculiar/asn1-schema@^2.0.32", "@peculiar/asn1-schema@^2.0.38":
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.0.38.tgz#98b6f12daad275ecd6774dfe31fb62f362900412"
+  integrity sha512-zZ64UpCTm9me15nuCpPgJghSdbEm8atcDQPCyK+bKXjZAQ1735NCZXCSCfbckbQ4MH36Rm9403n/qMq77LFDzQ==
+  dependencies:
+    "@types/asn1js" "^2.0.2"
+    asn1js "^2.1.1"
+    pvtsutils "^1.2.0"
+    tslib "^2.3.0"
+
+"@peculiar/json-schema@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@peculiar/json-schema/-/json-schema-1.1.12.tgz#fe61e85259e3b5ba5ad566cb62ca75b3d3cd5339"
+  integrity sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==
+  dependencies:
+    tslib "^2.0.0"
+
+"@peculiar/webcrypto@^1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@peculiar/webcrypto/-/webcrypto-1.1.7.tgz#ff02008612e67ab7cc2a92fce04a7f0e2a04b71c"
+  integrity sha512-aCNLYdHZkvGH+T8/YBOY33jrVGVuLIa3bpizeHXqwN+P4ZtixhA+kxEEWM1amZwUY2nY/iuj+5jdZn/zB7EPPQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.0.32"
+    "@peculiar/json-schema" "^1.1.12"
+    pvtsutils "^1.1.6"
+    tslib "^2.2.0"
+    webcrypto-core "^1.2.0"
+
 "@rollup/plugin-babel@^5.1.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"
@@ -1221,6 +1249,11 @@
   integrity sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
   dependencies:
     type-detect "4.0.8"
+
+"@types/asn1js@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/asn1js/-/asn1js-2.0.2.tgz#bb1992291381b5f06e22a829f2ae009267cdf8c5"
+  integrity sha512-t4YHCgtD+ERvH0FyxvNlYwJ2ezhqw7t+Ygh4urQ7dJER8i185JPv6oIM3ey5YQmGN6Zp9EMbpohkjZi9t3UxwA==
 
 "@types/babel__core@^7.1.7":
   version "7.1.14"
@@ -1592,6 +1625,13 @@ asn1@~0.2.3:
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
+
+asn1js@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-2.1.1.tgz#bb3896191ebb5fb1caeda73436a6c6e20a2eedff"
+  integrity sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==
+  dependencies:
+    pvutils latest
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
@@ -4867,6 +4907,18 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+pvtsutils@^1.1.6, pvtsutils@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.2.1.tgz#8212e846ca9afb21e40cebb0691755649f9f498a"
+  integrity sha512-Q867jEr30lBR2YSFFLZ0/XsEvpweqH6Kj096wmlRAFXrdRGPCNq2iz9B5Tk085EZ+OBZyYAVA5UhPkjSHGrUzQ==
+  dependencies:
+    tslib "^2.3.1"
+
+pvutils@latest:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.0.17.tgz#ade3c74dfe7178944fe44806626bd2e249d996bf"
+  integrity sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -5909,7 +5961,7 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@2.3.1, tslib@^2.0.3:
+tslib@2.3.1, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -6115,6 +6167,17 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+webcrypto-core@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/webcrypto-core/-/webcrypto-core-1.2.1.tgz#33f451a4c4faf159e74589436c80ca33998abad6"
+  integrity sha512-5+h1/e/A4eegCRTg+oQ9ehTJRTMwFhZazJ2RH1FP0VC3q1/0xl7x6SzzTwPxd/VTGc7kjuSEJGnfNgoLe5jNRQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.0.38"
+    "@peculiar/json-schema" "^1.1.12"
+    asn1js "^2.1.1"
+    pvtsutils "^1.2.0"
+    tslib "^2.3.1"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This took me way more trial and error than I'd like to admit and I don't think you'll want to use this PR as it is, but I wanted to at least provide a working proof-of-concept to show how this could be done. I think there are two big things here that are worth noting:
- Webcrypto seems to be entirely promise-based, so the package would have a breaking API change
- I had to convert the PKCS#1 key from the Node test into a PKCS#8 key, because webcrypto's `importKey` does not support PKCS#1

I'd be more than happy to continue working on this if you would like to provide some guidance on what you'd like to see to get this into a "mergeable" state. Would also be just as pleased if you took this and finished it yourself though :)

Thank you!
